### PR TITLE
update version from 1.1 to 3.0.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.radcortez.gradle:openjpa-gradle-plugin:1.1'
+        classpath 'com.radcortez.gradle:openjpa-gradle-plugin:3.0.0'
     }
 }
 ```


### PR DESCRIPTION
hello @radcortez I'm trying to use this plugin during https://issues.apache.org/jira/browse/FINERACT-700, due to https://github.com/schmutterer/gradle-openjpa/issues/8, and noticed that you actually have a (much) newer version 3.0.0 than the 1.1 mentioned in your README - perhaps you would like to adapt that example as suggested here?