### PR TITLE
Add new task for enhancing classes under test/java for unit testing

### DIFF
--- a/src/main/groovy/com/radcortez/gradle/plugin/openjpa/OpenJpaPlugin.groovy
+++ b/src/main/groovy/com/radcortez/gradle/plugin/openjpa/OpenJpaPlugin.groovy
@@ -2,6 +2,8 @@ package com.radcortez.gradle.plugin.openjpa
 
 import com.radcortez.gradle.plugin.openjpa.enhance.EnhanceExtension
 import com.radcortez.gradle.plugin.openjpa.enhance.EnhanceTask
+import com.radcortez.gradle.plugin.openjpa.enhanceTest.EnhanceTestExtension
+import com.radcortez.gradle.plugin.openjpa.enhanceTest.EnhanceTestTask
 import com.radcortez.gradle.plugin.openjpa.metamodel.MetamodelExtension
 import com.radcortez.gradle.plugin.openjpa.metamodel.MetamodelTask
 import com.radcortez.gradle.plugin.openjpa.sql.SqlExtension
@@ -19,6 +21,7 @@ class OpenJpaPlugin implements Plugin<Project> {
     void apply(final Project project) {
         project.extensions.create("openjpa", OpenJpaExtension, project)
         project.openjpa.extensions.create("enhance", EnhanceExtension, project)
+        project.openjpa.extensions.create("enhanceTest", EnhanceTestExtension, project)
         project.openjpa.extensions.create("metamodel", MetamodelExtension, project)
         project.openjpa.extensions.create("sql", SqlExtension, project)
 
@@ -28,6 +31,13 @@ class OpenJpaPlugin implements Plugin<Project> {
                 description: "Enhances entity classes with the OpenJPA Enhancer tool.",
                 dependsOn: "classes",
                 "enhance")
+
+        project.task(
+                type: EnhanceTestTask,
+                group: "OpenJPA",
+                description: "Enhances entity test classes with the OpenJPA Enhancer tool.",
+                dependsOn: "testClasses",
+                "enhanceTest")
 
         project.task(
                 type: MetamodelTask,

--- a/src/main/groovy/com/radcortez/gradle/plugin/openjpa/enhanceTest/EnhanceTestExtension.groovy
+++ b/src/main/groovy/com/radcortez/gradle/plugin/openjpa/enhanceTest/EnhanceTestExtension.groovy
@@ -1,0 +1,37 @@
+package com.radcortez.gradle.plugin.openjpa.enhanceTest
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+/**
+ * Extension for EnhanceTest task; to enhance classes under test/java for unit testing
+ */
+class EnhanceTestExtension {
+    Project project
+
+    @Input
+    @Optional
+    boolean addDefaultConstructor = true
+    @Input
+    @Optional
+    boolean enforcePropertyRestrictions = false
+    @Input
+    @Optional
+    boolean tmpClassLoader = false;
+
+    EnhanceTestExtension(final Project project) {
+        this.project = project
+
+        project.afterEvaluate() {
+            def runEnhance = false
+            project.tasks.testClasses.doLast {
+                runEnhance = true
+            }
+            project.tasks.enhanceTest.onlyIf {
+                runEnhance
+            }
+            project.tasks.testClasses.finalizedBy(project.tasks.enhanceTest)
+        }
+    }
+}

--- a/src/main/groovy/com/radcortez/gradle/plugin/openjpa/enhanceTest/EnhanceTestTask.groovy
+++ b/src/main/groovy/com/radcortez/gradle/plugin/openjpa/enhanceTest/EnhanceTestTask.groovy
@@ -1,0 +1,44 @@
+package com.radcortez.gradle.plugin.openjpa.enhanceTest
+
+import com.radcortez.gradle.plugin.openjpa.OpenJpa
+import com.radcortez.gradle.plugin.openjpa.OpenJpaExtension
+import com.radcortez.gradle.plugin.openjpa.enhance.EnhanceExtension
+import org.apache.openjpa.lib.util.Options
+import org.gradle.api.DefaultTask
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.TaskAction
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Task to enhance classes under test/java for unit testing
+ */
+class EnhanceTestTask extends DefaultTask {
+    static final Logger LOG = LoggerFactory.getLogger(EnhanceTestTask.class)
+
+    @TaskAction
+    void enhanceTest() {
+        SourceSet sourceSet = project.sourceSets.test
+        project.pluginManager.apply(JavaPlugin)
+
+        OpenJpaExtension openJpaConfiguration = project.extensions.findByType(OpenJpaExtension)
+        openJpaConfiguration.sourceSet = project.sourceSets.test
+        EnhanceExtension configuration = openJpaConfiguration.extensions.findByType(EnhanceExtension)
+
+        LOG.debug("persistenceXml = {}", openJpaConfiguration.persistenceXml)
+        LOG.debug("addDefaultConstructor = {}", configuration.addDefaultConstructor)
+        LOG.debug("enforcePropertyRestrictions = {}", configuration.enforcePropertyRestrictions)
+        LOG.debug("tmpClassLoader = {}", configuration.tmpClassLoader)
+
+        def openJpa = OpenJpa.openJpa(openJpaConfiguration.classpath, new Options([
+                "addDefaultConstructor"      : configuration.addDefaultConstructor.toBoolean(),
+                "enforcePropertyRestrictions": configuration.enforcePropertyRestrictions.toBoolean(),
+                "tmpClassLoader"             : configuration.tmpClassLoader.toBoolean(),
+                "propertiesFile"             : openJpaConfiguration.persistenceXmlFile
+        ]))
+
+        openJpa.enhance(openJpaConfiguration.classes as String[])
+        openJpa.dispose()
+    }
+}


### PR DESCRIPTION
Hi @radcortez 

I parametrized `OpenJpaExtension` with a SourceSet variable that defaults to `main` to avoid impacting the other processes.
I don't think it is possible to call the same task twice during the build, I went ahead and created a new `EnhanceTestTask`, which mainly sets the SourceSet variable in OpenJpaExtension to `test`.
When the variable is set then the test directory will be processed. 

I can then include this new task by adding in my project's gradle build file
```
openjpa {
  includes = ['**/bean/*.class']
  enhance {
    addDefaultConstructor true
    enforcePropertyRestrictions true
  }
  enhanceTest {
    addDefaultConstructor true
    enforcePropertyRestrictions true
  }
}
```

Let me know what you think.
Also I was not able to test metamodel and sql functionality since we're not using those in our project, I would appreciate if you could quickly verify this. Happy to change if you think there's anything that needs fixing.

Thank you!
Joan