### PR TITLE
Use compileClasspath instead of compile

### DIFF
--- a/src/main/groovy/com/radcortez/gradle/plugin/openjpa/metamodel/MetamodelTask.groovy
+++ b/src/main/groovy/com/radcortez/gradle/plugin/openjpa/metamodel/MetamodelTask.groovy
@@ -19,7 +19,7 @@ class MetamodelTask extends JavaCompile {
             SourceDirectorySet mainJava = project.sourceSets.main.java
             source(mainJava.srcDirs)
 
-            setClasspath(project.configurations.compile)
+            setClasspath(project.configurations.compileClasspath)
             setDestinationDir(project.file(configuration.metamodelOutputFolder))
 
             def openjpaConfig = project.configurations.detachedConfiguration(


### PR DESCRIPTION
- Fixes #14 

Fixes compatibility with modern Gradle, which complains about an unknown `compile` configuration.